### PR TITLE
Add theme color palette

### DIFF
--- a/new-theme/css/tailwind-output-rtl.css
+++ b/new-theme/css/tailwind-output-rtl.css
@@ -124,7 +124,7 @@
   /* 2 */
   border-style: solid;
   /* 2 */
-  border-color: #e5e7eb;
+  border-color: currentColor;
   /* 2 */
 }
 
@@ -552,4 +552,21 @@ video {
 
 [hidden]:where(:not([hidden="until-found"])) {
   display: none;
+}
+
+/* Theme color palette */
+
+:root {
+  --color-bg: #ffffff;
+  /* Main background */
+  --color-primary: #F3C100;
+  /* Brand color */
+  --color-accent: #68321A;
+  /* Strong accent (headings, links) */
+  --color-secondary: #80573B;
+  /* Muted UI elements */
+  --color-text: #221F23;
+  /* Body text / foreground */
+  --color-border: #E0E0E0;
+  --color-muted-bg: #F8F8F8;
 }

--- a/new-theme/css/tailwind-output.css
+++ b/new-theme/css/tailwind-output.css
@@ -124,7 +124,7 @@
   /* 2 */
   border-style: solid;
   /* 2 */
-  border-color: #e5e7eb;
+  border-color: currentColor;
   /* 2 */
 }
 
@@ -552,4 +552,21 @@ video {
 
 [hidden]:where(:not([hidden="until-found"])) {
   display: none;
+}
+
+/* Theme color palette */
+
+:root {
+  --color-bg: #ffffff;
+  /* Main background */
+  --color-primary: #F3C100;
+  /* Brand color */
+  --color-accent: #68321A;
+  /* Strong accent (headings, links) */
+  --color-secondary: #80573B;
+  /* Muted UI elements */
+  --color-text: #221F23;
+  /* Body text / foreground */
+  --color-border: #E0E0E0;
+  --color-muted-bg: #F8F8F8;
 }

--- a/new-theme/tailwind.config.js
+++ b/new-theme/tailwind.config.js
@@ -1,5 +1,18 @@
 module.exports = {
     content: [
         './**/*.php'
-    ]
+    ],
+    theme: {
+        colors: {
+            bg: 'var(--color-bg)',
+            primary: 'var(--color-primary)',
+            accent: 'var(--color-accent)',
+            secondary: 'var(--color-secondary)',
+            text: 'var(--color-text)',
+            border: 'var(--color-border)',
+            mutedBg: 'var(--color-muted-bg)',
+            transparent: 'transparent',
+            current: 'currentColor'
+        }
+    }
 };

--- a/new-theme/tailwind.css
+++ b/new-theme/tailwind.css
@@ -1,3 +1,14 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Theme color palette */
+:root {
+  --color-bg: #ffffff; /* Main background */
+  --color-primary: #F3C100; /* Brand color */
+  --color-accent: #68321A; /* Strong accent (headings, links) */
+  --color-secondary: #80573B; /* Muted UI elements */
+  --color-text: #221F23; /* Body text / foreground */
+  --color-border: #E0E0E0;
+  --color-muted-bg: #F8F8F8;
+}


### PR DESCRIPTION
## Summary
- define brand colors in `tailwind.css`
- expose palette in `tailwind.config.js`
- rebuild CSS assets

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688b9054d510832593d57085a268ddcf