### PR TITLE
Add navigation menu registrations

### DIFF
--- a/new-theme/functions.php
+++ b/new-theme/functions.php
@@ -3,6 +3,11 @@ function newtheme_setup() {
     load_theme_textdomain( 'new-theme', get_template_directory() . '/languages' );
     add_theme_support( 'title-tag' );
     add_theme_support( 'post-thumbnails' );
+    register_nav_menus( array(
+        'main_menu'     => __( 'Main Menu', 'new-theme' ),
+        'footer_menu'   => __( 'Footer Menu', 'new-theme' ),
+        'social_footer' => __( 'Social Footer Menu', 'new-theme' ),
+    ) );
 }
 add_action( 'after_setup_theme', 'newtheme_setup' );
 


### PR DESCRIPTION
## Summary
- add `register_nav_menus()` in `newtheme_setup()`

## Testing
- `php -l new-theme/functions.php`

------
https://chatgpt.com/codex/tasks/task_e_688b95101a98832581a0623530baa660