### PR TITLE
feat: support rtl spacing in header menu

### DIFF
--- a/new-theme/header.php
+++ b/new-theme/header.php
@@ -14,9 +14,15 @@
                 <?php ThemexStyler::siteLogo(); ?>
             </div>
             <nav class="hidden md:block">
-                <?php wp_nav_menu(array('theme_location' => 'main_menu', 'container_class' => 'menu flex space-x-4')); ?>
+                <?php
+                wp_nav_menu([
+                    'theme_location' => 'main_menu',
+                    'container'      => false,
+                    'menu_class'     => 'flex space-x-4 rtl:space-x-reverse',
+                ]);
+                ?>
             </nav>
-            <div class="flex items-center space-x-4">
+            <div class="flex items-center space-x-4 rtl:space-x-reverse">
                 <div class="search-form hidden md:block">
                     <?php get_search_form(); ?>
                 </div>


### PR DESCRIPTION
## Summary
- replace nav menu markup with RTL-aware Tailwind classes
- ensure header controls reverse spacing when in RTL mode

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f3515653083258ef9c2f05803c2ee