### PR TITLE
Switch main content wrapper to semantic element

### DIFF
--- a/new-theme/footer.php
+++ b/new-theme/footer.php
@@ -1,5 +1,5 @@
         </div> <!-- container -->
-    </div> <!-- main-content -->
+    </main> <!-- main-content -->
     <div class="move-top"></div>
     <div class="text-center my-4">
         <a referrerpolicy="origin" target="_blank" href="https://trustseal.enamad.ir/?id=67961&Code=">

--- a/new-theme/header.php
+++ b/new-theme/header.php
@@ -60,5 +60,5 @@
         </div>
         <?php } ?>
     </div>
-    <div class="main-content flex-1">
+    <main class="main-content flex-1">
         <div class="container mx-auto">


### PR DESCRIPTION
## Summary
- replace `<div>` wrappers with `<main>` for the main content section

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `php -l new-theme/header.php`
- `php -l new-theme/footer.php`
- `php -r '$html=file_get_contents("new-theme/header.php").file_get_contents("new-theme/footer.php"); $dom=new DOMDocument; @$dom->loadHTML($html); echo "main tags: ".$dom->getElementsByTagName("main")->length, "\n";'`

------
https://chatgpt.com/codex/tasks/task_e_688f377bb9488325993b4fd933a8db7e