### PR TITLE
Use palette utilities for slider caption

### DIFF
--- a/new-theme/css/tailwind-output-rtl.css
+++ b/new-theme/css/tailwind-output-rtl.css
@@ -554,19 +554,267 @@ video {
   display: none;
 }
 
+.container {
+  width: 100%;
+}
+
+@media (min-width: 640px) {
+  .container {
+    max-width: 640px;
+  }
+}
+
+@media (min-width: 768px) {
+  .container {
+    max-width: 768px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .container {
+    max-width: 1024px;
+  }
+}
+
+@media (min-width: 1280px) {
+  .container {
+    max-width: 1280px;
+  }
+}
+
+@media (min-width: 1536px) {
+  .container {
+    max-width: 1536px;
+  }
+}
+
+.static {
+  position: static;
+}
+
+.absolute {
+  position: absolute;
+}
+
+.relative {
+  position: relative;
+}
+
+.inset-x-0 {
+  left: 0px;
+  right: 0px;
+}
+
+.bottom-0 {
+  bottom: 0px;
+}
+
+.mx-1 {
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+}
+
+.mx-auto {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.my-4 {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+.mb-4 {
+  margin-bottom: 1rem;
+}
+
+.inline-block {
+  display: inline-block;
+}
+
+.flex {
+  display: flex;
+}
+
+.grid {
+  display: grid;
+}
+
+.hidden {
+  display: none;
+}
+
+.h-20 {
+  height: 5rem;
+}
+
+.h-auto {
+  height: auto;
+}
+
+.min-h-screen {
+  min-height: 100vh;
+}
+
+.w-full {
+  width: 100%;
+}
+
+.max-w-3xl {
+  max-width: 48rem;
+}
+
+.flex-1 {
+  flex: 1 1 0%;
+}
+
+.flex-shrink-0 {
+  flex-shrink: 0;
+}
+
+.transform {
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.flex-col {
+  flex-direction: column;
+}
+
+.items-center {
+  align-items: center;
+}
+
+.justify-between {
+  justify-content: space-between;
+}
+
+.gap-4 {
+  gap: 1rem;
+}
+
+.space-x-4 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(1rem * var(--tw-space-x-reverse));
+  margin-left: calc(1rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.overflow-hidden {
+  overflow: hidden;
+}
+
+.bg-bg {
+  --tw-bg-opacity: 1;
+  background-color: rgb(var(--color-bg) / var(--tw-bg-opacity, 1));
+}
+
+.bg-primary {
+  --tw-bg-opacity: 1;
+  background-color: rgb(var(--color-primary) / var(--tw-bg-opacity, 1));
+}
+
+.bg-secondary {
+  --tw-bg-opacity: 1;
+  background-color: rgb(var(--color-secondary) / var(--tw-bg-opacity, 1));
+}
+
+.bg-text\/60 {
+  background-color: rgb(var(--color-text) / 0.6);
+}
+
+.p-4 {
+  padding: 1rem;
+}
+
+.py-4 {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+.py-6 {
+  padding-top: 1.5rem;
+  padding-bottom: 1.5rem;
+}
+
+.py-8 {
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.text-2xl {
+  font-size: 1.5rem;
+  line-height: 2rem;
+}
+
+.text-lg {
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+}
+
+.text-sm {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+
+.font-bold {
+  font-weight: 700;
+}
+
+.text-accent {
+  --tw-text-opacity: 1;
+  color: rgb(var(--color-accent) / var(--tw-text-opacity, 1));
+}
+
+.text-bg {
+  --tw-text-opacity: 1;
+  color: rgb(var(--color-bg) / var(--tw-text-opacity, 1));
+}
+
+.text-text {
+  --tw-text-opacity: 1;
+  color: rgb(var(--color-text) / var(--tw-text-opacity, 1));
+}
+
+.transition-transform {
+  transition-property: transform;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.duration-700 {
+  transition-duration: 700ms;
+}
+
 /* Theme color palette */
 
 :root {
-  --color-bg: #ffffff;
+  --color-bg: 255 255 255;
   /* Main background */
-  --color-primary: #F3C100;
+  --color-primary: 243 193 0;
   /* Brand color */
-  --color-accent: #68321A;
+  --color-accent: 104 50 26;
   /* Strong accent (headings, links) */
-  --color-secondary: #80573B;
+  --color-secondary: 128 87 59;
   /* Muted UI elements */
-  --color-text: #221F23;
+  --color-text: 34 31 35;
   /* Body text / foreground */
-  --color-border: #E0E0E0;
-  --color-muted-bg: #F8F8F8;
+  --color-border: 224 224 224;
+  --color-muted-bg: 248 248 248;
+}
+
+@media (min-width: 768px) {
+  .md\:block {
+    display: block;
+  }
+
+  .md\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.rtl\:space-x-reverse:where([dir="rtl"], [dir="rtl"] *) > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 1;
 }

--- a/new-theme/css/tailwind-output.css
+++ b/new-theme/css/tailwind-output.css
@@ -554,19 +554,267 @@ video {
   display: none;
 }
 
+.container {
+  width: 100%;
+}
+
+@media (min-width: 640px) {
+  .container {
+    max-width: 640px;
+  }
+}
+
+@media (min-width: 768px) {
+  .container {
+    max-width: 768px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .container {
+    max-width: 1024px;
+  }
+}
+
+@media (min-width: 1280px) {
+  .container {
+    max-width: 1280px;
+  }
+}
+
+@media (min-width: 1536px) {
+  .container {
+    max-width: 1536px;
+  }
+}
+
+.static {
+  position: static;
+}
+
+.absolute {
+  position: absolute;
+}
+
+.relative {
+  position: relative;
+}
+
+.inset-x-0 {
+  left: 0px;
+  right: 0px;
+}
+
+.bottom-0 {
+  bottom: 0px;
+}
+
+.mx-1 {
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+}
+
+.mx-auto {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.my-4 {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+.mb-4 {
+  margin-bottom: 1rem;
+}
+
+.inline-block {
+  display: inline-block;
+}
+
+.flex {
+  display: flex;
+}
+
+.grid {
+  display: grid;
+}
+
+.hidden {
+  display: none;
+}
+
+.h-20 {
+  height: 5rem;
+}
+
+.h-auto {
+  height: auto;
+}
+
+.min-h-screen {
+  min-height: 100vh;
+}
+
+.w-full {
+  width: 100%;
+}
+
+.max-w-3xl {
+  max-width: 48rem;
+}
+
+.flex-1 {
+  flex: 1 1 0%;
+}
+
+.flex-shrink-0 {
+  flex-shrink: 0;
+}
+
+.transform {
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.flex-col {
+  flex-direction: column;
+}
+
+.items-center {
+  align-items: center;
+}
+
+.justify-between {
+  justify-content: space-between;
+}
+
+.gap-4 {
+  gap: 1rem;
+}
+
+.space-x-4 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(1rem * var(--tw-space-x-reverse));
+  margin-left: calc(1rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.overflow-hidden {
+  overflow: hidden;
+}
+
+.bg-bg {
+  --tw-bg-opacity: 1;
+  background-color: rgb(var(--color-bg) / var(--tw-bg-opacity, 1));
+}
+
+.bg-primary {
+  --tw-bg-opacity: 1;
+  background-color: rgb(var(--color-primary) / var(--tw-bg-opacity, 1));
+}
+
+.bg-secondary {
+  --tw-bg-opacity: 1;
+  background-color: rgb(var(--color-secondary) / var(--tw-bg-opacity, 1));
+}
+
+.bg-text\/60 {
+  background-color: rgb(var(--color-text) / 0.6);
+}
+
+.p-4 {
+  padding: 1rem;
+}
+
+.py-4 {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+.py-6 {
+  padding-top: 1.5rem;
+  padding-bottom: 1.5rem;
+}
+
+.py-8 {
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.text-2xl {
+  font-size: 1.5rem;
+  line-height: 2rem;
+}
+
+.text-lg {
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+}
+
+.text-sm {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+
+.font-bold {
+  font-weight: 700;
+}
+
+.text-accent {
+  --tw-text-opacity: 1;
+  color: rgb(var(--color-accent) / var(--tw-text-opacity, 1));
+}
+
+.text-bg {
+  --tw-text-opacity: 1;
+  color: rgb(var(--color-bg) / var(--tw-text-opacity, 1));
+}
+
+.text-text {
+  --tw-text-opacity: 1;
+  color: rgb(var(--color-text) / var(--tw-text-opacity, 1));
+}
+
+.transition-transform {
+  transition-property: transform;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.duration-700 {
+  transition-duration: 700ms;
+}
+
 /* Theme color palette */
 
 :root {
-  --color-bg: #ffffff;
+  --color-bg: 255 255 255;
   /* Main background */
-  --color-primary: #F3C100;
+  --color-primary: 243 193 0;
   /* Brand color */
-  --color-accent: #68321A;
+  --color-accent: 104 50 26;
   /* Strong accent (headings, links) */
-  --color-secondary: #80573B;
+  --color-secondary: 128 87 59;
   /* Muted UI elements */
-  --color-text: #221F23;
+  --color-text: 34 31 35;
   /* Body text / foreground */
-  --color-border: #E0E0E0;
-  --color-muted-bg: #F8F8F8;
+  --color-border: 224 224 224;
+  --color-muted-bg: 248 248 248;
+}
+
+@media (min-width: 768px) {
+  .md\:block {
+    display: block;
+  }
+
+  .md\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.rtl\:space-x-reverse:where([dir="rtl"], [dir="rtl"] *) > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 1;
 }

--- a/new-theme/module-slider.php
+++ b/new-theme/module-slider.php
@@ -16,7 +16,7 @@ if ($slider_query->have_posts()) :
                 <?php if (has_post_thumbnail()) : ?>
                     <?php the_post_thumbnail('full', ['class' => 'w-full h-auto']); ?>
                 <?php endif; ?>
-                <div class="caption absolute bottom-0 inset-x-0 bg-black bg-opacity-50 text-white p-4">
+                <div class="caption absolute bottom-0 inset-x-0 bg-text/60 text-bg p-4">
                     <?php the_title('<h2 class="text-lg">', '</h2>'); ?>
                     <?php the_content(); ?>
                 </div>

--- a/new-theme/tailwind.config.js
+++ b/new-theme/tailwind.config.js
@@ -4,13 +4,13 @@ module.exports = {
     ],
     theme: {
         colors: {
-            bg: 'var(--color-bg)',
-            primary: 'var(--color-primary)',
-            accent: 'var(--color-accent)',
-            secondary: 'var(--color-secondary)',
-            text: 'var(--color-text)',
-            border: 'var(--color-border)',
-            mutedBg: 'var(--color-muted-bg)',
+            bg: 'rgb(var(--color-bg) / <alpha-value>)',
+            primary: 'rgb(var(--color-primary) / <alpha-value>)',
+            accent: 'rgb(var(--color-accent) / <alpha-value>)',
+            secondary: 'rgb(var(--color-secondary) / <alpha-value>)',
+            text: 'rgb(var(--color-text) / <alpha-value>)',
+            border: 'rgb(var(--color-border) / <alpha-value>)',
+            mutedBg: 'rgb(var(--color-muted-bg) / <alpha-value>)',
             transparent: 'transparent',
             current: 'currentColor'
         }

--- a/new-theme/tailwind.css
+++ b/new-theme/tailwind.css
@@ -4,11 +4,11 @@
 
 /* Theme color palette */
 :root {
-  --color-bg: #ffffff; /* Main background */
-  --color-primary: #F3C100; /* Brand color */
-  --color-accent: #68321A; /* Strong accent (headings, links) */
-  --color-secondary: #80573B; /* Muted UI elements */
-  --color-text: #221F23; /* Body text / foreground */
-  --color-border: #E0E0E0;
-  --color-muted-bg: #F8F8F8;
+  --color-bg: 255 255 255; /* Main background */
+  --color-primary: 243 193 0; /* Brand color */
+  --color-accent: 104 50 26; /* Strong accent (headings, links) */
+  --color-secondary: 128 87 59; /* Muted UI elements */
+  --color-text: 34 31 35; /* Body text / foreground */
+  --color-border: 224 224 224;
+  --color-muted-bg: 248 248 248;
 }


### PR DESCRIPTION
## Summary
- replace fixed colors on slider caption with palette-based `bg-text/60` and `text-bg`
- configure Tailwind palette to support color opacity utilities
- rebuild CSS assets

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f39b8ddbc8325a46b2aef23826c9d