### PR TITLE
Restore metadata and navigation to content modules

### DIFF
--- a/new-theme/module-course.php
+++ b/new-theme/module-course.php
@@ -1,14 +1,58 @@
 <?php
-// Display single course
+// Display single course with author info, attachments and navigation
+the_post();
 ?>
-<div class="max-w-3xl mx-auto py-8">
+<div class="max-w-3xl mx-auto py-8 text-right">
     <?php if (has_post_thumbnail()) : ?>
         <div class="mb-4">
-            <?php the_post_thumbnail('full', ['class' => 'w-full h-auto']); ?>
+            <?php the_post_thumbnail('full', ['class' => 'w-full h-auto rounded']); ?>
         </div>
     <?php endif; ?>
-    <h1 class="text-2xl font-bold mb-4"><?php the_title(); ?></h1>
-    <div>
+
+    <h1 class="text-2xl font-bold mb-4 text-primary"><?php the_title(); ?></h1>
+
+    <?php
+    $authors = [];
+    if (function_exists('get_coauthors')) {
+        $authors = get_coauthors($post->ID);
+    } else {
+        $authors[] = get_userdata($post->post_author);
+    }
+    ?>
+    <div class="mb-6 flex flex-wrap justify-center gap-4">
+        <?php foreach ($authors as $author) : ?>
+            <a class="flex flex-col items-center" href="<?php echo get_author_posts_url($author->ID); ?>">
+                <?php echo get_avatar($author->ID, 64, '', '', ['class' => 'rounded-full mb-2']); ?>
+                <span class="text-sm text-text"><?php echo esc_html($author->display_name); ?></span>
+            </a>
+        <?php endforeach; ?>
+    </div>
+
+    <div class="prose max-w-none text-text">
         <?php the_content(); ?>
     </div>
+
+    <?php
+    $attachments = get_attached_media('', $post->ID);
+    unset($attachments[get_post_thumbnail_id($post->ID)]);
+    if (!empty($attachments)) :
+    ?>
+        <div class="mt-6">
+            <h2 class="text-lg font-semibold mb-2 text-secondary"><?php _e('پیوندها', 'new-theme'); ?></h2>
+            <ul class="bg-mutedBg rounded p-4 space-y-2">
+                <?php foreach ($attachments as $attachment) : ?>
+                    <li>
+                        <a class="text-primary underline" href="<?php echo wp_get_attachment_url($attachment->ID); ?>">
+                            <?php echo esc_html(get_the_title($attachment)); ?>
+                        </a>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        </div>
+    <?php endif; ?>
+
+    <nav class="mt-8 flex flex-row-reverse justify-between text-sm text-primary">
+        <div><?php previous_post_link('%link', '&larr; ' . __('قبلی', 'new-theme')); ?></div>
+        <div><?php next_post_link('%link', __('بعدی', 'new-theme') . ' &rarr;'); ?></div>
+    </nav>
 </div>

--- a/new-theme/module-library.php
+++ b/new-theme/module-library.php
@@ -1,14 +1,39 @@
 <?php
-// Display single library post
+// Display single library post with attachments and navigation
+the_post();
 ?>
-<div class="max-w-3xl mx-auto py-8">
+<div class="max-w-3xl mx-auto py-8 text-right">
     <?php if (has_post_thumbnail()) : ?>
         <div class="mb-4">
-            <?php the_post_thumbnail('full', ['class' => 'w-full h-auto']); ?>
+            <?php the_post_thumbnail('full', ['class' => 'w-full h-auto rounded']); ?>
         </div>
     <?php endif; ?>
-    <h1 class="text-2xl font-bold mb-4"><?php the_title(); ?></h1>
-    <div>
+    <h1 class="text-2xl font-bold mb-4 text-primary"><?php the_title(); ?></h1>
+    <div class="prose max-w-none text-text">
         <?php the_content(); ?>
     </div>
+
+    <?php
+    $attachments = get_attached_media('', $post->ID);
+    unset($attachments[get_post_thumbnail_id($post->ID)]);
+    if (!empty($attachments)) :
+    ?>
+        <div class="mt-6">
+            <h2 class="text-lg font-semibold mb-2 text-secondary"><?php _e('دانلود الحاقات', 'new-theme'); ?></h2>
+            <ul class="bg-mutedBg rounded p-4 space-y-2">
+                <?php foreach ($attachments as $attachment) : ?>
+                    <li>
+                        <a class="text-primary underline" href="<?php echo wp_get_attachment_url($attachment->ID); ?>">
+                            <?php echo esc_html(get_the_title($attachment)); ?>
+                        </a>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        </div>
+    <?php endif; ?>
+
+    <nav class="mt-8 flex flex-row-reverse justify-between text-sm text-primary">
+        <div><?php previous_post_link('%link', '&larr; ' . __('قبلی', 'new-theme')); ?></div>
+        <div><?php next_post_link('%link', __('بعدی', 'new-theme') . ' &rarr;'); ?></div>
+    </nav>
 </div>

--- a/new-theme/module-meeting.php
+++ b/new-theme/module-meeting.php
@@ -1,14 +1,57 @@
 <?php
-// Display single meeting post
+// Display single meeting post with author info, attachments and navigation
+the_post();
 ?>
-<div class="max-w-3xl mx-auto py-8">
+<div class="max-w-3xl mx-auto py-8 text-right">
     <?php if (has_post_thumbnail()) : ?>
         <div class="mb-4">
-            <?php the_post_thumbnail('full', ['class' => 'w-full h-auto']); ?>
+            <?php the_post_thumbnail('full', ['class' => 'w-full h-auto rounded']); ?>
         </div>
     <?php endif; ?>
-    <h1 class="text-2xl font-bold mb-4"><?php the_title(); ?></h1>
-    <div>
+    <h1 class="text-2xl font-bold mb-4 text-primary"><?php the_title(); ?></h1>
+
+    <?php
+    $authors = [];
+    if (function_exists('get_coauthors')) {
+        $authors = get_coauthors($post->ID);
+    } else {
+        $authors[] = get_userdata($post->post_author);
+    }
+    ?>
+    <div class="mb-6 flex flex-wrap justify-center gap-4">
+        <?php foreach ($authors as $author) : ?>
+            <a class="flex flex-col items-center" href="<?php echo get_author_posts_url($author->ID); ?>">
+                <?php echo get_avatar($author->ID, 64, '', '', ['class' => 'rounded-full mb-2']); ?>
+                <span class="text-sm text-text"><?php echo esc_html($author->display_name); ?></span>
+            </a>
+        <?php endforeach; ?>
+    </div>
+
+    <div class="prose max-w-none text-text">
         <?php the_content(); ?>
     </div>
+
+    <?php
+    $attachments = get_attached_media('', $post->ID);
+    unset($attachments[get_post_thumbnail_id($post->ID)]);
+    if (!empty($attachments)) :
+    ?>
+        <div class="mt-6">
+            <h2 class="text-lg font-semibold mb-2 text-secondary"><?php _e('پیوندها', 'new-theme'); ?></h2>
+            <ul class="bg-mutedBg rounded p-4 space-y-2">
+                <?php foreach ($attachments as $attachment) : ?>
+                    <li>
+                        <a class="text-primary underline" href="<?php echo wp_get_attachment_url($attachment->ID); ?>">
+                            <?php echo esc_html(get_the_title($attachment)); ?>
+                        </a>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        </div>
+    <?php endif; ?>
+
+    <nav class="mt-8 flex flex-row-reverse justify-between text-sm text-primary">
+        <div><?php previous_post_link('%link', '&larr; ' . __('قبلی', 'new-theme')); ?></div>
+        <div><?php next_post_link('%link', __('بعدی', 'new-theme') . ' &rarr;'); ?></div>
+    </nav>
 </div>

--- a/new-theme/module-plan.php
+++ b/new-theme/module-plan.php
@@ -1,14 +1,40 @@
 <?php
-// Display single plan post
+// Display single plan post with related courses and navigation
+the_post();
 ?>
-<div class="max-w-3xl mx-auto py-8">
+<div class="max-w-4xl mx-auto py-8 text-right">
     <?php if (has_post_thumbnail()) : ?>
         <div class="mb-4">
-            <?php the_post_thumbnail('full', ['class' => 'w-full h-auto']); ?>
+            <?php the_post_thumbnail('full', ['class' => 'w-full h-auto rounded']); ?>
         </div>
     <?php endif; ?>
-    <h1 class="text-2xl font-bold mb-4"><?php the_title(); ?></h1>
-    <div>
-        <?php the_content(); ?>
+    <h1 class="text-2xl font-bold mb-4 text-primary"><?php the_title(); ?></h1>
+    <div class="prose max-w-none text-text">
+        <?php
+        if (get_post_meta(get_the_ID(), '_plan_stuview', true) === 'show') {
+            $users = get_post_meta(get_the_ID(), 'users', true);
+            if (is_array($users)) {
+                echo '<p class="mb-4">' . sprintf(__('تعداد دانشجویان: %s', 'new-theme'), '<span class="font-semibold">' . count($users) . '</span>') . '</p>';
+            }
+        }
+        the_content();
+        ?>
     </div>
+
+    <?php
+    $plancat = get_post_meta(get_the_ID(), '_plan_category', true);
+    if (!empty($plancat)) :
+    ?>
+        <div class="mt-6">
+            <h2 class="text-lg font-semibold mb-2 text-secondary"><?php _e('دوره‌های مرتبط', 'new-theme'); ?></h2>
+            <div class="bg-mutedBg rounded p-4">
+                <?php echo do_shortcode('[courses category="' . esc_attr($plancat) . '" number="50" columns="4" order="date"]'); ?>
+            </div>
+        </div>
+    <?php endif; ?>
+
+    <nav class="mt-8 flex flex-row-reverse justify-between text-sm text-primary">
+        <div><?php previous_post_link('%link', '&larr; ' . __('قبلی', 'new-theme')); ?></div>
+        <div><?php next_post_link('%link', __('بعدی', 'new-theme') . ' &rarr;'); ?></div>
+    </nav>
 </div>


### PR DESCRIPTION
## Summary
- add author avatars and names to course and meeting templates
- surface attached files in course, library, and meeting templates using Tailwind styles
- show related courses and student counts for plans
- add RTL-friendly previous/next navigation across modules

## Testing
- `php -l new-theme/module-course.php`
- `php -l new-theme/module-library.php`
- `php -l new-theme/module-meeting.php`
- `php -l new-theme/module-plan.php`


------
https://chatgpt.com/codex/tasks/task_e_688f3eeee454832581fc6bbd7ede9d3d