### PR TITLE
Refactor single module layout into reusable template

### DIFF
--- a/new-theme/module-course.php
+++ b/new-theme/module-course.php
@@ -1,58 +1,7 @@
 <?php
-// Display single course with author info, attachments and navigation
-the_post();
-?>
-<div class="max-w-3xl mx-auto py-8 text-right">
-    <?php if (has_post_thumbnail()) : ?>
-        <div class="mb-4">
-            <?php the_post_thumbnail('full', ['class' => 'w-full h-auto rounded']); ?>
-        </div>
-    <?php endif; ?>
-
-    <h1 class="text-2xl font-bold mb-4 text-primary"><?php the_title(); ?></h1>
-
-    <?php
-    $authors = [];
-    if (function_exists('get_coauthors')) {
-        $authors = get_coauthors($post->ID);
-    } else {
-        $authors[] = get_userdata($post->post_author);
-    }
-    ?>
-    <div class="mb-6 flex flex-wrap justify-center gap-4">
-        <?php foreach ($authors as $author) : ?>
-            <a class="flex flex-col items-center" href="<?php echo get_author_posts_url($author->ID); ?>">
-                <?php echo get_avatar($author->ID, 64, '', '', ['class' => 'rounded-full mb-2']); ?>
-                <span class="text-sm text-text"><?php echo esc_html($author->display_name); ?></span>
-            </a>
-        <?php endforeach; ?>
-    </div>
-
-    <div class="prose max-w-none text-text">
-        <?php the_content(); ?>
-    </div>
-
-    <?php
-    $attachments = get_attached_media('', $post->ID);
-    unset($attachments[get_post_thumbnail_id($post->ID)]);
-    if (!empty($attachments)) :
-    ?>
-        <div class="mt-6">
-            <h2 class="text-lg font-semibold mb-2 text-secondary"><?php _e('پیوندها', 'new-theme'); ?></h2>
-            <ul class="bg-mutedBg rounded p-4 space-y-2">
-                <?php foreach ($attachments as $attachment) : ?>
-                    <li>
-                        <a class="text-primary underline" href="<?php echo wp_get_attachment_url($attachment->ID); ?>">
-                            <?php echo esc_html(get_the_title($attachment)); ?>
-                        </a>
-                    </li>
-                <?php endforeach; ?>
-            </ul>
-        </div>
-    <?php endif; ?>
-
-    <nav class="mt-8 flex flex-row-reverse justify-between text-sm text-primary">
-        <div><?php previous_post_link('%link', '&larr; ' . __('قبلی', 'new-theme')); ?></div>
-        <div><?php next_post_link('%link', __('بعدی', 'new-theme') . ' &rarr;'); ?></div>
-    </nav>
-</div>
+// Display single course with author info, attachments and navigation via generic layout.
+$context = [
+    'show_authors'     => true,
+    'attachment_title' => __('پیوندها', 'new-theme'),
+];
+get_template_part('parts/single', 'generic', $context);

--- a/new-theme/module-library.php
+++ b/new-theme/module-library.php
@@ -1,39 +1,6 @@
 <?php
-// Display single library post with attachments and navigation
-the_post();
-?>
-<div class="max-w-3xl mx-auto py-8 text-right">
-    <?php if (has_post_thumbnail()) : ?>
-        <div class="mb-4">
-            <?php the_post_thumbnail('full', ['class' => 'w-full h-auto rounded']); ?>
-        </div>
-    <?php endif; ?>
-    <h1 class="text-2xl font-bold mb-4 text-primary"><?php the_title(); ?></h1>
-    <div class="prose max-w-none text-text">
-        <?php the_content(); ?>
-    </div>
-
-    <?php
-    $attachments = get_attached_media('', $post->ID);
-    unset($attachments[get_post_thumbnail_id($post->ID)]);
-    if (!empty($attachments)) :
-    ?>
-        <div class="mt-6">
-            <h2 class="text-lg font-semibold mb-2 text-secondary"><?php _e('دانلود الحاقات', 'new-theme'); ?></h2>
-            <ul class="bg-mutedBg rounded p-4 space-y-2">
-                <?php foreach ($attachments as $attachment) : ?>
-                    <li>
-                        <a class="text-primary underline" href="<?php echo wp_get_attachment_url($attachment->ID); ?>">
-                            <?php echo esc_html(get_the_title($attachment)); ?>
-                        </a>
-                    </li>
-                <?php endforeach; ?>
-            </ul>
-        </div>
-    <?php endif; ?>
-
-    <nav class="mt-8 flex flex-row-reverse justify-between text-sm text-primary">
-        <div><?php previous_post_link('%link', '&larr; ' . __('قبلی', 'new-theme')); ?></div>
-        <div><?php next_post_link('%link', __('بعدی', 'new-theme') . ' &rarr;'); ?></div>
-    </nav>
-</div>
+// Display single library post using generic layout with attachments.
+$context = [
+    'attachment_title' => __('دانلود الحاقات', 'new-theme'),
+];
+get_template_part('parts/single', 'generic', $context);

--- a/new-theme/module-meeting.php
+++ b/new-theme/module-meeting.php
@@ -1,57 +1,7 @@
 <?php
-// Display single meeting post with author info, attachments and navigation
-the_post();
-?>
-<div class="max-w-3xl mx-auto py-8 text-right">
-    <?php if (has_post_thumbnail()) : ?>
-        <div class="mb-4">
-            <?php the_post_thumbnail('full', ['class' => 'w-full h-auto rounded']); ?>
-        </div>
-    <?php endif; ?>
-    <h1 class="text-2xl font-bold mb-4 text-primary"><?php the_title(); ?></h1>
-
-    <?php
-    $authors = [];
-    if (function_exists('get_coauthors')) {
-        $authors = get_coauthors($post->ID);
-    } else {
-        $authors[] = get_userdata($post->post_author);
-    }
-    ?>
-    <div class="mb-6 flex flex-wrap justify-center gap-4">
-        <?php foreach ($authors as $author) : ?>
-            <a class="flex flex-col items-center" href="<?php echo get_author_posts_url($author->ID); ?>">
-                <?php echo get_avatar($author->ID, 64, '', '', ['class' => 'rounded-full mb-2']); ?>
-                <span class="text-sm text-text"><?php echo esc_html($author->display_name); ?></span>
-            </a>
-        <?php endforeach; ?>
-    </div>
-
-    <div class="prose max-w-none text-text">
-        <?php the_content(); ?>
-    </div>
-
-    <?php
-    $attachments = get_attached_media('', $post->ID);
-    unset($attachments[get_post_thumbnail_id($post->ID)]);
-    if (!empty($attachments)) :
-    ?>
-        <div class="mt-6">
-            <h2 class="text-lg font-semibold mb-2 text-secondary"><?php _e('پیوندها', 'new-theme'); ?></h2>
-            <ul class="bg-mutedBg rounded p-4 space-y-2">
-                <?php foreach ($attachments as $attachment) : ?>
-                    <li>
-                        <a class="text-primary underline" href="<?php echo wp_get_attachment_url($attachment->ID); ?>">
-                            <?php echo esc_html(get_the_title($attachment)); ?>
-                        </a>
-                    </li>
-                <?php endforeach; ?>
-            </ul>
-        </div>
-    <?php endif; ?>
-
-    <nav class="mt-8 flex flex-row-reverse justify-between text-sm text-primary">
-        <div><?php previous_post_link('%link', '&larr; ' . __('قبلی', 'new-theme')); ?></div>
-        <div><?php next_post_link('%link', __('بعدی', 'new-theme') . ' &rarr;'); ?></div>
-    </nav>
-</div>
+// Display single meeting with author info and attachments via generic layout.
+$context = [
+    'show_authors'     => true,
+    'attachment_title' => __('پیوندها', 'new-theme'),
+];
+get_template_part('parts/single', 'generic', $context);

--- a/new-theme/module-plan.php
+++ b/new-theme/module-plan.php
@@ -1,40 +1,27 @@
 <?php
-// Display single plan post with related courses and navigation
-the_post();
-?>
-<div class="max-w-4xl mx-auto py-8 text-right">
-    <?php if (has_post_thumbnail()) : ?>
-        <div class="mb-4">
-            <?php the_post_thumbnail('full', ['class' => 'w-full h-auto rounded']); ?>
-        </div>
-    <?php endif; ?>
-    <h1 class="text-2xl font-bold mb-4 text-primary"><?php the_title(); ?></h1>
-    <div class="prose max-w-none text-text">
-        <?php
-        if (get_post_meta(get_the_ID(), '_plan_stuview', true) === 'show') {
-            $users = get_post_meta(get_the_ID(), 'users', true);
-            if (is_array($users)) {
-                echo '<p class="mb-4">' . sprintf(__('تعداد دانشجویان: %s', 'new-theme'), '<span class="font-semibold">' . count($users) . '</span>') . '</p>';
-            }
-        }
-        the_content();
-        ?>
-    </div>
+// Display single plan post with related courses using generic layout.
+$before = '';
+if (get_post_meta(get_the_ID(), '_plan_stuview', true) === 'show') {
+    $users = get_post_meta(get_the_ID(), 'users', true);
+    if (is_array($users)) {
+        $before .= '<p class="mb-4">' . sprintf(__('تعداد دانشجویان: %s', 'new-theme'), '<span class="font-semibold">' . count($users) . '</span>') . '</p>';
+    }
+}
 
-    <?php
-    $plancat = get_post_meta(get_the_ID(), '_plan_category', true);
-    if (!empty($plancat)) :
-    ?>
-        <div class="mt-6">
-            <h2 class="text-lg font-semibold mb-2 text-secondary"><?php _e('دوره‌های مرتبط', 'new-theme'); ?></h2>
-            <div class="bg-mutedBg rounded p-4">
-                <?php echo do_shortcode('[courses category="' . esc_attr($plancat) . '" number="50" columns="4" order="date"]'); ?>
-            </div>
-        </div>
-    <?php endif; ?>
+$after = '';
+$plancat = get_post_meta(get_the_ID(), '_plan_category', true);
+if (!empty($plancat)) {
+    $after .= '<div class="mt-6">';
+    $after .= '<h2 class="text-lg font-semibold mb-2 text-secondary">' . __('دوره‌های مرتبط', 'new-theme') . '</h2>';
+    $after .= '<div class="bg-mutedBg rounded p-4">';
+    $after .= do_shortcode('[courses category="' . esc_attr($plancat) . '" number="50" columns="4" order="date"]');
+    $after .= '</div></div>';
+}
 
-    <nav class="mt-8 flex flex-row-reverse justify-between text-sm text-primary">
-        <div><?php previous_post_link('%link', '&larr; ' . __('قبلی', 'new-theme')); ?></div>
-        <div><?php next_post_link('%link', __('بعدی', 'new-theme') . ' &rarr;'); ?></div>
-    </nav>
-</div>
+$context = [
+    'container_class'     => 'max-w-4xl mx-auto py-8 text-right',
+    'show_attachments'    => false,
+    'before_content_html' => $before,
+    'after_content_html'  => $after,
+];
+get_template_part('parts/single', 'generic', $context);

--- a/new-theme/parts/single-generic.php
+++ b/new-theme/parts/single-generic.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Generic single post layout.
+ *
+ * Accepts context via $args when loaded with get_template_part().
+ *
+ * @package new-theme
+ */
+
+// Default context values.
+$defaults = [
+    'container_class'     => 'max-w-3xl mx-auto py-8 text-right',
+    'show_authors'        => false,
+    'show_attachments'    => true,
+    'attachment_title'    => __('پیوندها', 'new-theme'),
+    'before_content_html' => '',
+    'after_content_html'  => '',
+];
+
+// Merge passed args with defaults and allow filtering.
+$context = isset($args) ? wp_parse_args($args, $defaults) : $defaults;
+$context = apply_filters('new_theme_single_generic_context', $context, get_post_type());
+
+the_post();
+?>
+<div class="<?php echo esc_attr($context['container_class']); ?>">
+    <?php if (has_post_thumbnail()) : ?>
+        <div class="mb-4">
+            <?php the_post_thumbnail('full', ['class' => 'w-full h-auto rounded']); ?>
+        </div>
+    <?php endif; ?>
+
+    <h1 class="text-2xl font-bold mb-4 text-primary"><?php the_title(); ?></h1>
+
+    <?php if (!empty($context['show_authors'])) : ?>
+        <?php
+        $authors = function_exists('get_coauthors') ? get_coauthors($post->ID) : [get_userdata($post->post_author)];
+        ?>
+        <div class="mb-6 flex flex-wrap justify-center gap-4">
+            <?php foreach ($authors as $author) : ?>
+                <a class="flex flex-col items-center" href="<?php echo esc_url(get_author_posts_url($author->ID)); ?>">
+                    <?php echo get_avatar($author->ID, 64, '', '', ['class' => 'rounded-full mb-2']); ?>
+                    <span class="text-sm text-text"><?php echo esc_html($author->display_name); ?></span>
+                </a>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+
+    <div class="prose max-w-none text-text">
+        <?php echo $context['before_content_html']; ?>
+        <?php the_content(); ?>
+    </div>
+
+    <?php echo $context['after_content_html']; ?>
+
+    <?php if (!empty($context['show_attachments'])) :
+        $attachments = get_attached_media('', get_the_ID());
+        unset($attachments[get_post_thumbnail_id(get_the_ID())]);
+        if (!empty($attachments)) : ?>
+        <div class="mt-6">
+            <h2 class="text-lg font-semibold mb-2 text-secondary"><?php echo esc_html($context['attachment_title']); ?></h2>
+            <ul class="bg-mutedBg rounded p-4 space-y-2">
+                <?php foreach ($attachments as $attachment) : ?>
+                    <li>
+                        <a class="text-primary underline" href="<?php echo esc_url(wp_get_attachment_url($attachment->ID)); ?>">
+                            <?php echo esc_html(get_the_title($attachment)); ?>
+                        </a>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        </div>
+        <?php endif; ?>
+    <?php endif; ?>
+
+    <nav class="mt-8 flex flex-row-reverse justify-between text-sm text-primary">
+        <div><?php previous_post_link('%link', '&larr; ' . __('قبلی', 'new-theme')); ?></div>
+        <div><?php next_post_link('%link', __('بعدی', 'new-theme') . ' &rarr;'); ?></div>
+    </nav>
+</div>


### PR DESCRIPTION
## Summary
- add a new `parts/single-generic.php` partial providing a shared layout for single posts
- refactor course, library, meeting, and plan modules to use the generic layout and pass context

## Testing
- `php -l new-theme/parts/single-generic.php new-theme/module-course.php new-theme/module-library.php new-theme/module-meeting.php new-theme/module-plan.php`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f4090fcdc8325aba3527db8c84031