### PR TITLE
Enable custom logo support with Customizer section

### DIFF
--- a/new-theme/functions.php
+++ b/new-theme/functions.php
@@ -5,6 +5,12 @@ function newtheme_setup() {
     load_theme_textdomain( 'new-theme', get_template_directory() . '/languages' );
     add_theme_support( 'title-tag' );
     add_theme_support( 'post-thumbnails' );
+    add_theme_support( 'custom-logo', [
+        'height'      => 100,
+        'width'       => 300,
+        'flex-height' => true,
+        'flex-width'  => true,
+    ] );
     register_nav_menus( array(
         'main_menu'     => __( 'Main Menu', 'new-theme' ),
         'footer_menu'   => __( 'Footer Menu', 'new-theme' ),
@@ -12,6 +18,25 @@ function newtheme_setup() {
     ) );
 }
 add_action( 'after_setup_theme', 'newtheme_setup' );
+
+function newtheme_customize_register( $wp_customize ) {
+    $wp_customize->add_section(
+        'newtheme_theme_options',
+        [
+            'title'    => __( 'Theme Options', 'new-theme' ),
+            'priority' => 30,
+        ]
+    );
+    $control = $wp_customize->get_control( 'custom_logo' );
+    if ( $control ) {
+        $control->section     = 'newtheme_theme_options';
+        $control->height      = 100;
+        $control->width       = 300;
+        $control->flex_height = true;
+        $control->flex_width  = true;
+    }
+}
+add_action( 'customize_register', 'newtheme_customize_register' );
 
 function newtheme_enqueue_scripts() {
     $dir = get_template_directory_uri();


### PR DESCRIPTION
## Summary
- add `custom-logo` theme support with flexible dimensions
- add Theme Options section in Customizer and move logo control there

## Testing
- `php -l new-theme/functions.php`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f46651dc883258aad3561f4413686