### PR TITLE
Hide nav submenus until hover

### DIFF
--- a/new-theme/css/tailwind-output-rtl.css
+++ b/new-theme/css/tailwind-output-rtl.css
@@ -609,6 +609,18 @@ video {
   bottom: 0px;
 }
 
+.left-2 {
+  left: 0.5rem;
+}
+
+.right-2 {
+  right: 0.5rem;
+}
+
+.top-1\/2 {
+  top: 50%;
+}
+
 .mx-1 {
   margin-left: 0.25rem;
   margin-right: 0.25rem;
@@ -624,8 +636,24 @@ video {
   margin-bottom: 1rem;
 }
 
+.mb-2 {
+  margin-bottom: 0.5rem;
+}
+
 .mb-4 {
   margin-bottom: 1rem;
+}
+
+.mb-6 {
+  margin-bottom: 1.5rem;
+}
+
+.mt-6 {
+  margin-top: 1.5rem;
+}
+
+.mt-8 {
+  margin-top: 2rem;
 }
 
 .inline-block {
@@ -664,6 +692,14 @@ video {
   max-width: 48rem;
 }
 
+.max-w-4xl {
+  max-width: 56rem;
+}
+
+.max-w-none {
+  max-width: none;
+}
+
 .flex-1 {
   flex: 1 1 0%;
 }
@@ -672,16 +708,33 @@ video {
   flex-shrink: 0;
 }
 
+.-translate-y-1\/2 {
+  --tw-translate-y: -50%;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
 .transform {
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.flex-row-reverse {
+  flex-direction: row-reverse;
 }
 
 .flex-col {
   flex-direction: column;
 }
 
+.flex-wrap {
+  flex-wrap: wrap;
+}
+
 .items-center {
   align-items: center;
+}
+
+.justify-center {
+  justify-content: center;
 }
 
 .justify-between {
@@ -698,13 +751,32 @@ video {
   margin-left: calc(1rem * calc(1 - var(--tw-space-x-reverse)));
 }
 
+.space-y-2 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.5rem * var(--tw-space-y-reverse));
+}
+
 .overflow-hidden {
   overflow: hidden;
+}
+
+.rounded {
+  border-radius: 0.25rem;
+}
+
+.rounded-full {
+  border-radius: 9999px;
 }
 
 .bg-bg {
   --tw-bg-opacity: 1;
   background-color: rgb(var(--color-bg) / var(--tw-bg-opacity, 1));
+}
+
+.bg-mutedBg {
+  --tw-bg-opacity: 1;
+  background-color: rgb(var(--color-muted-bg) / var(--tw-bg-opacity, 1));
 }
 
 .bg-primary {
@@ -719,6 +791,10 @@ video {
 
 .bg-text\/60 {
   background-color: rgb(var(--color-text) / 0.6);
+}
+
+.p-2 {
+  padding: 0.5rem;
 }
 
 .p-4 {
@@ -744,6 +820,10 @@ video {
   text-align: center;
 }
 
+.text-right {
+  text-align: right;
+}
+
 .text-2xl {
   font-size: 1.5rem;
   line-height: 2rem;
@@ -763,6 +843,10 @@ video {
   font-weight: 700;
 }
 
+.font-semibold {
+  font-weight: 600;
+}
+
 .text-accent {
   --tw-text-opacity: 1;
   color: rgb(var(--color-accent) / var(--tw-text-opacity, 1));
@@ -773,9 +857,23 @@ video {
   color: rgb(var(--color-bg) / var(--tw-text-opacity, 1));
 }
 
+.text-primary {
+  --tw-text-opacity: 1;
+  color: rgb(var(--color-primary) / var(--tw-text-opacity, 1));
+}
+
+.text-secondary {
+  --tw-text-opacity: 1;
+  color: rgb(var(--color-secondary) / var(--tw-text-opacity, 1));
+}
+
 .text-text {
   --tw-text-opacity: 1;
   color: rgb(var(--color-text) / var(--tw-text-opacity, 1));
+}
+
+.underline {
+  text-decoration-line: underline;
 }
 
 .transition-transform {
@@ -805,9 +903,27 @@ video {
   --color-muted-bg: 248 248 248;
 }
 
+/* Hide submenus by default */
+
+nav .sub-menu {
+  display: none;
+}
+
+nav li:hover > .sub-menu {
+  display: block;
+}
+
+.group:hover .group-hover\:block {
+  display: block;
+}
+
 @media (min-width: 768px) {
   .md\:block {
     display: block;
+  }
+
+  .md\:hidden {
+    display: none;
   }
 
   .md\:grid-cols-3 {

--- a/new-theme/css/tailwind-output.css
+++ b/new-theme/css/tailwind-output.css
@@ -609,6 +609,18 @@ video {
   bottom: 0px;
 }
 
+.left-2 {
+  left: 0.5rem;
+}
+
+.right-2 {
+  right: 0.5rem;
+}
+
+.top-1\/2 {
+  top: 50%;
+}
+
 .mx-1 {
   margin-left: 0.25rem;
   margin-right: 0.25rem;
@@ -624,8 +636,24 @@ video {
   margin-bottom: 1rem;
 }
 
+.mb-2 {
+  margin-bottom: 0.5rem;
+}
+
 .mb-4 {
   margin-bottom: 1rem;
+}
+
+.mb-6 {
+  margin-bottom: 1.5rem;
+}
+
+.mt-6 {
+  margin-top: 1.5rem;
+}
+
+.mt-8 {
+  margin-top: 2rem;
 }
 
 .inline-block {
@@ -664,6 +692,14 @@ video {
   max-width: 48rem;
 }
 
+.max-w-4xl {
+  max-width: 56rem;
+}
+
+.max-w-none {
+  max-width: none;
+}
+
 .flex-1 {
   flex: 1 1 0%;
 }
@@ -672,16 +708,33 @@ video {
   flex-shrink: 0;
 }
 
+.-translate-y-1\/2 {
+  --tw-translate-y: -50%;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
 .transform {
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.flex-row-reverse {
+  flex-direction: row-reverse;
 }
 
 .flex-col {
   flex-direction: column;
 }
 
+.flex-wrap {
+  flex-wrap: wrap;
+}
+
 .items-center {
   align-items: center;
+}
+
+.justify-center {
+  justify-content: center;
 }
 
 .justify-between {
@@ -698,13 +751,32 @@ video {
   margin-left: calc(1rem * calc(1 - var(--tw-space-x-reverse)));
 }
 
+.space-y-2 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.5rem * var(--tw-space-y-reverse));
+}
+
 .overflow-hidden {
   overflow: hidden;
+}
+
+.rounded {
+  border-radius: 0.25rem;
+}
+
+.rounded-full {
+  border-radius: 9999px;
 }
 
 .bg-bg {
   --tw-bg-opacity: 1;
   background-color: rgb(var(--color-bg) / var(--tw-bg-opacity, 1));
+}
+
+.bg-mutedBg {
+  --tw-bg-opacity: 1;
+  background-color: rgb(var(--color-muted-bg) / var(--tw-bg-opacity, 1));
 }
 
 .bg-primary {
@@ -719,6 +791,10 @@ video {
 
 .bg-text\/60 {
   background-color: rgb(var(--color-text) / 0.6);
+}
+
+.p-2 {
+  padding: 0.5rem;
 }
 
 .p-4 {
@@ -744,6 +820,10 @@ video {
   text-align: center;
 }
 
+.text-right {
+  text-align: right;
+}
+
 .text-2xl {
   font-size: 1.5rem;
   line-height: 2rem;
@@ -763,6 +843,10 @@ video {
   font-weight: 700;
 }
 
+.font-semibold {
+  font-weight: 600;
+}
+
 .text-accent {
   --tw-text-opacity: 1;
   color: rgb(var(--color-accent) / var(--tw-text-opacity, 1));
@@ -773,9 +857,23 @@ video {
   color: rgb(var(--color-bg) / var(--tw-text-opacity, 1));
 }
 
+.text-primary {
+  --tw-text-opacity: 1;
+  color: rgb(var(--color-primary) / var(--tw-text-opacity, 1));
+}
+
+.text-secondary {
+  --tw-text-opacity: 1;
+  color: rgb(var(--color-secondary) / var(--tw-text-opacity, 1));
+}
+
 .text-text {
   --tw-text-opacity: 1;
   color: rgb(var(--color-text) / var(--tw-text-opacity, 1));
+}
+
+.underline {
+  text-decoration-line: underline;
 }
 
 .transition-transform {
@@ -805,9 +903,27 @@ video {
   --color-muted-bg: 248 248 248;
 }
 
+/* Hide submenus by default */
+
+nav .sub-menu {
+  display: none;
+}
+
+nav li:hover > .sub-menu {
+  display: block;
+}
+
+.group:hover .group-hover\:block {
+  display: block;
+}
+
 @media (min-width: 768px) {
   .md\:block {
     display: block;
+  }
+
+  .md\:hidden {
+    display: none;
   }
 
   .md\:grid-cols-3 {

--- a/new-theme/header.php
+++ b/new-theme/header.php
@@ -15,6 +15,31 @@
             </div>
             <nav class="hidden md:block">
                 <?php
+                add_filter(
+                    'nav_menu_css_class',
+                    function ( $classes, $item, $args, $depth ) {
+                        if ( $args->theme_location === 'main_menu' && in_array( 'menu-item-has-children', $classes, true ) ) {
+                            $classes[] = 'group';
+                        }
+                        return $classes;
+                    },
+                    10,
+                    4
+                );
+
+                add_filter(
+                    'nav_menu_submenu_css_class',
+                    function ( $classes, $args, $depth ) {
+                        if ( $args->theme_location === 'main_menu' ) {
+                            $classes[] = 'hidden';
+                            $classes[] = 'group-hover:block';
+                        }
+                        return $classes;
+                    },
+                    10,
+                    3
+                );
+
                 wp_nav_menu([
                     'theme_location' => 'main_menu',
                     'container'      => false,

--- a/new-theme/tailwind.css
+++ b/new-theme/tailwind.css
@@ -12,3 +12,12 @@
   --color-border: 224 224 224;
   --color-muted-bg: 248 248 248;
 }
+
+/* Hide submenus by default */
+nav .sub-menu {
+  display: none;
+}
+
+nav li:hover > .sub-menu {
+  display: block;
+}


### PR DESCRIPTION
## Summary
- hide navigation submenus by default
- reveal submenus on hover using Tailwind `hidden`/`group-hover:block`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f4746363083259d16d9ad085d97e9