### PR TITLE
Add minimal Toluehagh Bootstrap theme

### DIFF
--- a/wp-content/themes/toluehagh-bootstrap/footer.php
+++ b/wp-content/themes/toluehagh-bootstrap/footer.php
@@ -1,0 +1,6 @@
+<footer>
+    <p>&copy; <?php echo date( 'Y' ); ?> <?php bloginfo( 'name' ); ?></p>
+</footer>
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/wp-content/themes/toluehagh-bootstrap/functions.php
+++ b/wp-content/themes/toluehagh-bootstrap/functions.php
@@ -1,0 +1,3 @@
+<?php
+// Theme functions file.
+

--- a/wp-content/themes/toluehagh-bootstrap/header.php
+++ b/wp-content/themes/toluehagh-bootstrap/header.php
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+    <meta charset="<?php bloginfo( 'charset' ); ?>">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+<header>
+    <h1><a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php bloginfo( 'name' ); ?></a></h1>
+</header>

--- a/wp-content/themes/toluehagh-bootstrap/home.php
+++ b/wp-content/themes/toluehagh-bootstrap/home.php
@@ -1,0 +1,12 @@
+<?php get_header(); ?>
+<main>
+<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
+    <article>
+        <h2><?php the_title(); ?></h2>
+        <?php the_content(); ?>
+    </article>
+<?php endwhile; else : ?>
+    <p><?php esc_html_e( 'No posts found.', 'toluehagh-bootstrap' ); ?></p>
+<?php endif; ?>
+</main>
+<?php get_footer(); ?>

--- a/wp-content/themes/toluehagh-bootstrap/index.php
+++ b/wp-content/themes/toluehagh-bootstrap/index.php
@@ -1,0 +1,12 @@
+<?php get_header(); ?>
+<main>
+<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
+    <article>
+        <h2><?php the_title(); ?></h2>
+        <?php the_content(); ?>
+    </article>
+<?php endwhile; else : ?>
+    <p><?php esc_html_e( 'No posts found.', 'toluehagh-bootstrap' ); ?></p>
+<?php endif; ?>
+</main>
+<?php get_footer(); ?>

--- a/wp-content/themes/toluehagh-bootstrap/page.php
+++ b/wp-content/themes/toluehagh-bootstrap/page.php
@@ -1,0 +1,10 @@
+<?php get_header(); ?>
+<main>
+<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
+    <article>
+        <h1><?php the_title(); ?></h1>
+        <?php the_content(); ?>
+    </article>
+<?php endwhile; endif; ?>
+</main>
+<?php get_footer(); ?>

--- a/wp-content/themes/toluehagh-bootstrap/single.php
+++ b/wp-content/themes/toluehagh-bootstrap/single.php
@@ -1,0 +1,10 @@
+<?php get_header(); ?>
+<main>
+<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
+    <article>
+        <h1><?php the_title(); ?></h1>
+        <?php the_content(); ?>
+    </article>
+<?php endwhile; endif; ?>
+</main>
+<?php get_footer(); ?>

--- a/wp-content/themes/toluehagh-bootstrap/style.css
+++ b/wp-content/themes/toluehagh-bootstrap/style.css
@@ -1,0 +1,13 @@
+/*
+Theme Name: Toluehagh Bootstrap
+Theme URI: https://example.com/
+Author: Toluehagh
+Author URI: https://example.com/
+Description: A minimal Bootstrap-based theme for WordPress.
+Version: 1.0.0
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: toluehagh-bootstrap
+*/
+
+/* Add theme styles here */


### PR DESCRIPTION
## Summary
- add Toluehagh Bootstrap theme scaffold under `wp-content/themes`
- include basic templates and style header for the new theme

## Testing
- `find wp-content/themes/toluehagh-bootstrap -maxdepth 1 -name '*.php' -exec php -l {} \;`


------
https://chatgpt.com/codex/tasks/task_e_688f4d7c70988325a679f1301a14755d