### PR TITLE
feat: rebuild header with bootstrap

### DIFF
--- a/new tolu/assets/css/custom.css
+++ b/new tolu/assets/css/custom.css
@@ -1,11 +1,11 @@
 :root {
-  --primary: #0d6efd;
-  --secondary: #6c757d;
-  --success: #198754;
-  --info: #0dcaf0;
-  --warning: #ffc107;
-  --danger: #dc3545;
-  --light: #f8f9fa;
-  --dark: #212529;
+  --bs-primary: #0d6efd;
+  --bs-secondary: #6c757d;
+  --bs-success: #198754;
+  --bs-info: #0dcaf0;
+  --bs-warning: #ffc107;
+  --bs-danger: #dc3545;
+  --bs-light: #f8f9fa;
+  --bs-dark: #212529;
 }
 

--- a/new tolu/functions.php
+++ b/new tolu/functions.php
@@ -8,3 +8,33 @@ function toluehagh_bootstrap_enqueue_scripts() {
 }
 add_action('wp_enqueue_scripts', 'toluehagh_bootstrap_enqueue_scripts');
 
+function toluehagh_bootstrap_setup() {
+    add_theme_support('title-tag');
+    add_theme_support('custom-logo', array(
+        'height'      => 100,
+        'width'       => 300,
+        'flex-height' => true,
+        'flex-width'  => true,
+    ));
+    register_nav_menus(array(
+        'primary' => __('Primary Menu', 'toluehagh-bootstrap'),
+    ));
+}
+add_action('after_setup_theme', 'toluehagh_bootstrap_setup');
+
+function toluehagh_bootstrap_nav_menu_css_class($classes, $item, $args, $depth) {
+    if (isset($args->theme_location) && 'primary' === $args->theme_location) {
+        $classes[] = 'nav-item';
+    }
+    return $classes;
+}
+add_filter('nav_menu_css_class', 'toluehagh_bootstrap_nav_menu_css_class', 10, 4);
+
+function toluehagh_bootstrap_nav_menu_link_attributes($atts, $item, $args, $depth) {
+    if (isset($args->theme_location) && 'primary' === $args->theme_location) {
+        $atts['class'] = trim(($atts['class'] ?? '') . ' nav-link');
+    }
+    return $atts;
+}
+add_filter('nav_menu_link_attributes', 'toluehagh_bootstrap_nav_menu_link_attributes', 10, 4);
+

--- a/new tolu/header.php
+++ b/new tolu/header.php
@@ -1,11 +1,48 @@
 <!DOCTYPE html>
 <html <?php language_attributes(); ?>>
 <head>
-    <meta charset="<?php bloginfo( 'charset' ); ?>">
+    <meta charset="<?php bloginfo('charset'); ?>">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <?php wp_head(); ?>
 </head>
 <body <?php body_class(); ?>>
-<header>
-    <h1><a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php bloginfo( 'name' ); ?></a></h1>
-</header>
+<?php wp_body_open(); ?>
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+    <div class="container">
+        <a class="navbar-brand" href="<?php echo esc_url(home_url('/')); ?>">
+            <?php
+            if (function_exists('the_custom_logo') && has_custom_logo()) {
+                the_custom_logo();
+            } else {
+                bloginfo('name');
+            }
+            ?>
+        </a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#primaryNavbar" aria-controls="primaryNavbar" aria-expanded="false" aria-label="<?php esc_attr_e('Toggle navigation', 'toluehagh-bootstrap'); ?>">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="primaryNavbar">
+            <?php
+            wp_nav_menu(array(
+                'theme_location' => 'primary',
+                'container' => false,
+                'menu_class' => 'navbar-nav ms-auto mb-2 mb-lg-0',
+                'fallback_cb' => '__return_false'
+            ));
+            ?>
+            <form class="d-flex ms-lg-3" role="search" method="get" action="<?php echo esc_url(home_url('/')); ?>">
+                <input class="form-control me-2" type="search" placeholder="<?php esc_attr_e('Search', 'toluehagh-bootstrap'); ?>" value="<?php echo get_search_query(); ?>" name="s">
+                <button class="btn btn-outline-light" type="submit"><?php _e('Search', 'toluehagh-bootstrap'); ?></button>
+            </form>
+            <ul class="navbar-nav mb-2 mb-lg-0 ms-lg-3">
+                <li class="nav-item">
+                    <?php if (is_user_logged_in()) : ?>
+                        <a class="nav-link" href="<?php echo esc_url(wp_logout_url()); ?>"><?php _e('Log out', 'toluehagh-bootstrap'); ?></a>
+                    <?php else : ?>
+                        <a class="nav-link" href="<?php echo esc_url(wp_login_url()); ?>"><?php _e('Log in', 'toluehagh-bootstrap'); ?></a>
+                    <?php endif; ?>
+                </li>
+            </ul>
+        </div>
+    </div>
+</nav>


### PR DESCRIPTION
## Summary
- rebuild header template with Bootstrap 5 navigation, search, and auth links
- register menu, logo, and Bootstrap nav helpers in theme setup
- apply Bootstrap color variables to match palette

## Testing
- `php -l 'new tolu/header.php'`
- `php -l 'new tolu/functions.php'`


------
https://chatgpt.com/codex/tasks/task_e_688f6df5e644832585bfcd8eef87fa74